### PR TITLE
feat: clean dependencies on reruns

### DIFF
--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -141,7 +141,13 @@ runs:
           --auth-key "${{ inputs.oban-token }}"
       shell: bash
 
-    - if: steps.cache.outputs.cache-hit != 'true'
+    - if: github.run_attempt != '1'
+      name: Clean Dependencies
+      run: |
+        mix deps.clean --all
+        mix clean
+
+    - if: github.run_attempt != '1' || steps.cache.outputs.cache-hit != 'true'
       name: Install Dependencies
       run: mix deps.get
       shell: bash


### PR DESCRIPTION
Shamelessly stolen from this Felt action: https://github.com/felt/ultimate-elixir-ci/blob/main/.github/actions/elixir-setup/action.yml#L97

If a person reruns a GitHub action, it will cause Elixir to clean all dependencies and re fetch them. This will trigger a rebuild in what ever action using this composite action. This makes a nice alternative to having to clear the cache if there is an issue.