### PR TITLE
fix: update release please configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,13 +16,9 @@ jobs:
         name: Release
         uses: google-github-actions/release-please-action@v4
         with:
-          release-type: node
-          package-name: actions-elixir
           token: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
-          extra-files: |
-            docker-build/README.md
-            setup/README.md
-            README.md
+          config-file: release-please-config.json
+          manifest-file: .release-please-manifest.json
 
       - if: ${{ steps.release.outputs.release_created }}
         name: Checkout

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,13 @@
   "separate-pull-requests": false,
   "draft-pull-request": true,
   "packages": {
-    ".": {}
+    ".": {
+      "release-type": "simple",
+      "extra-files": [
+        "docker-build/README.md",
+        "setup/README.md",
+        "README.md"
+      ]
+    }
   }
 }


### PR DESCRIPTION
Due to the major change, seems release please no longer accepts all of the options via the action. Moves that configuration to the config file.