### PR TITLE
chore: [SRE-830] add load flag

### DIFF
--- a/docker-build/action.yaml
+++ b/docker-build/action.yaml
@@ -63,6 +63,13 @@ inputs:
       (Optional) A list of labels to be added to the default ones when
       pushing the image.
     required: false
+  load:
+    default: false
+    description: >-
+      (Optional) When set to true, the `load` input acts as a shorthand for --output=type=docker,
+      automatically loading the single-platform build result into the local Docker images.
+      This is useful for testing the image locally to the GHA instance.
+    required: false
   oban-fingerprint:
     description: >-
       (Optional) Public key for fetching the oban pro repository data.
@@ -233,6 +240,7 @@ runs:
         push: ${{ inputs.push }}
         secrets: ${{ steps.inputs.outputs.secrets }}
         tags: ${{ steps.metadata.outputs.tags }}
+        load: ${{ inputs.load }}
 
     - id: outputs
       name: Get Outputs


### PR DESCRIPTION
Adding the `load` flag to allow for the image to be available for subsequent processing steps i.e. https://github.com/stordco/logiwa_writer/pull/108/files#diff-944291df2c9c06359d37cc8833d182d705c9e8c3108e7cfe132d61a06e9133ddR176 