### PR TITLE
feat: setup hexpm mirror and timeout for better reliability

### DIFF
--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -96,8 +96,13 @@ runs:
       with:
         otp-version: ${{ inputs.otp-version }}
         elixir-version: ${{ inputs.elixir-version }}
+        install-hex: true
+        install-rebar: true
         version-file: ${{ !inputs.elixir-version && '.tool-versions' || null }}
         version-type: strict
+      env:
+        HEXPM_MIRRORS: https://repo.hex.pm,https://cdn.jsdelivr.net/hex
+        HEXPM_TIMEOUT: 60000
 
     - id: cache
       name: Cache


### PR DESCRIPTION
This adds the factory droid recommendation to solve some hexpm repo timeout issues.

https://github.com/stordco/parcel-service/pull/571#issuecomment-2299456023
https://hex.pm/docs/mirrors