### PR TITLE
fix: remove cache restore key causing incorrect restore files

### DIFF
--- a/setup/action.yaml
+++ b/setup/action.yaml
@@ -112,7 +112,6 @@ runs:
         restore-keys: |
           elixir-setup-${{ inputs.cache-version }}-elixir-${{ steps.beam.outputs.elixir-version }}-otp-${{ steps.beam.outputs.otp-version }}-${{ inputs.cache-name }}-${{ hashFiles('mix.lock') }}-
           elixir-setup-${{ inputs.cache-version }}-elixir-${{ steps.beam.outputs.elixir-version }}-otp-${{ steps.beam.outputs.otp-version }}-${{ inputs.cache-name }}-
-          elixir-setup-${{ inputs.cache-version }}-elixir-${{ steps.beam.outputs.elixir-version }}-otp-${{ steps.beam.outputs.otp-version }}-
         path: ${{ inputs.cache-path }}
 
     - if: ${{ inputs.github-token }}


### PR DESCRIPTION
We are seeing issues where PRs are pulling caches from other _jobs_ on the branch instead of pulling a cache from the same job but on the main branch. This _is not_ intended behaviour from what I can understand from the GitHub docs. However, it does slow down our CI times a ton by requiring a full compile, so this might hopefully fix it quickly.